### PR TITLE
Handle 429 Errors

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -13,7 +13,7 @@ const configuration = v2.createConfiguration();
 const apiInstance = new v2.LogsApi(configuration);
 
 async function getLogs(apiInstance, params) {
-    let nextPage = null;
+    let nextPage = params.cursor ?? null;
     let n = 1;
     do {
         console.log(`Requesting page ${n} ${nextPage ? `with cursor ${nextPage} ` : ``}`);


### PR DESCRIPTION
When trying to parse a lot of logs, I was receiving 429 HTTP Responses from Datadog due to reaching the API Request Limits.

This would mean the application crashes and all progress is lost.

I've made it instead sleep for 1 second and re-attempt the current page until it's successful.

![Screenshot 2023-06-20 at 11 52 31](https://github.com/wegift/datadog-downloader/assets/8949315/ba35683b-71b5-4067-a35b-e3135373605b)
