### PR TITLE
streamable ndjson support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,12 @@ App keys are personal to your profile and can be generated in personal settings.
 --output    Path of json file to write results to, default 'results.json'
 
 --format
-    json (default): Save the final output as a single JSON object
+    json: Save the final output as a single JSON object (default)
     ndjson: Stream the output to New Line Delimited JSON file (Less memory intensive on larger datasets)
+
+--cursor    Next Page cursor position, useful to restart from a certain point if it crashed (Only works with streamable data formats)
+
+--append    Enable appending data stream to output file instead of overwriting (Only works with streamable data formats)
 ```
 
 Note: Date/times are parsed by JS `Date` constructor, e.g. 2022-01-01

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ App keys are personal to your profile and can be generated in personal settings.
 --pageSize  How many results to download at a time, default 1000 limit of 5000
 
 --output    Path of json file to write results to, default 'results.json'
+
+--format
+    json (default): Save the final output as a single JSON object
+    ndjson: Stream the output to New Line Delimited JSON file (Less memory intensive on larger datasets)
 ```
 
 Note: Date/times are parsed by JS `Date` constructor, e.g. 2022-01-01

--- a/index.mjs
+++ b/index.mjs
@@ -5,6 +5,7 @@ import chalk from "chalk";
 import * as dotenv from "dotenv";
 import * as fs from "fs";
 import yargs from "yargs";
+
 const argv = yargs(process.argv).argv;
 
 dotenv.config();
@@ -13,20 +14,37 @@ const configuration = v2.createConfiguration();
 const apiInstance = new v2.LogsApi(configuration);
 
 async function getLogs(apiInstance, params) {
-    const data = [];
-
     let nextPage = null;
     let n = 0;
     do {
         console.log(`Requesting page ${++n} ${nextPage ? `with cursor ${nextPage} ` : ``}`);
         const query = nextPage ? { ...params, pageCursor: nextPage } : params;
         const result = await apiInstance.listLogsGet(query);
-        data.push(...result.data);
+        result.data.forEach((row) => processLog(params.format, row));
         nextPage = result?.meta?.page?.after;
         console.log(`${result.data.length} results (${data.length} total)`);
     } while (nextPage);
 
-    return data;
+    return true;
+}
+
+const data = [];
+let writer = null;
+async function processLog(format, row) {
+    switch (format) {
+        case "json":
+            data.push(row);
+            break;
+        case "ndjson":
+            if (writer === null) {
+                writer = fs.createWriteStream(argv.output ?? 'results.json', {flags: 'w'});
+            }
+            writer.write(JSON.stringify(row, null) + '\n');  
+            break;
+        default:
+            console.log(chalk.red(`Unknown format ${format}`));
+            process.exit(1);
+    }
 }
 
 function oneYearAgo() {
@@ -39,6 +57,7 @@ const initialParams = {
     filterFrom: argv.from ? new Date(argv.from) : oneYearAgo(),
     filterTo: argv.to ? new Date(argv.to) : new Date(),
     pageLimit: argv.pageSize ? Math.min(argv.pageSize, 5000) : 1000,
+    format: argv.format ?? "json",
 };
 
 if (!initialParams.filterQuery) {
@@ -49,17 +68,22 @@ if (!initialParams.filterQuery) {
 console.log(chalk.cyan("Downloading logs:\n" + JSON.stringify(initialParams, null, 2) + "\n"));
 
 (async function () {
-    let data;
     try {
-        data = await getLogs(apiInstance, initialParams);
+        await getLogs(apiInstance, initialParams);
     } catch (e) {
         console.log(chalk.red(e.message));
         process.exit(1);
     }
-
-    const outputFile = argv.output ?? "results.json";
-    console.log(chalk.cyan(`\nWriting ${data.length} logs to ${outputFile}`));
-    fs.writeFileSync(outputFile, JSON.stringify(data, null, 2));
+    switch (initialParams.format) {
+        case "ndjson":
+            writer.end();
+            break;
+        case "json":
+            const outputFile = argv.output ?? "results.json";
+            console.log(chalk.cyan(`\nWriting ${data.length} logs to ${outputFile}`));
+            fs.writeFileSync(outputFile, JSON.stringify(data, null, 2));
+            break;
+    }
 
     console.log(chalk.green("Done!"));
 })();

--- a/index.mjs
+++ b/index.mjs
@@ -5,7 +5,6 @@ import chalk from "chalk";
 import * as dotenv from "dotenv";
 import * as fs from "fs";
 import yargs from "yargs";
-
 const argv = yargs(process.argv).argv;
 
 dotenv.config();


### PR DESCRIPTION
Adds `--format=ndjson` support to stream the output to a newline delimited JSON file.

Helps with really large datasets, preventing the heapsize fatal errors when building an enormous regular JSON file.